### PR TITLE
PATCH: validate tracing ID

### DIFF
--- a/containers/proxy/config/conf.d/tracing.conf
+++ b/containers/proxy/config/conf.d/tracing.conf
@@ -1,8 +1,14 @@
 # this creates a tracing ID that will be propagated to all following requests.
 # it will use the current RequestID but prefer the value from an incoming X-Tracing-ID header.
 # this allows re-using the tracingID for sub requests made by an application.
-# example: user->proxy->webserver->php (Uvex TYPO3)->proxy->webserver->php (Uvex Shopware) will use the same tracingID
+# example: user->proxy->webserver->php->proxy->solr will use the same tracingID
 map $http_x_tracing_id $traceId {
-    default   $http_x_tracing_id;
-    ""        $request_id;
+	# the incoming header is empty (or does not exist) -> use current requestID
+	"" $request_id;
+
+	# the incoming header is a hex string -> use it
+	"~^[0-9a-fA-F]+$" $http_x_tracing_id;
+
+	# fallthrough: incoming header is set but not a hex string -> use hardcoded string to make it clear something happened
+	default "invalid";
 }

--- a/containers/proxy/config/conf.d/tracing.conf
+++ b/containers/proxy/config/conf.d/tracing.conf
@@ -6,9 +6,9 @@ map $http_x_tracing_id $traceId {
 	# the incoming header is empty (or does not exist) -> use current requestID
 	"" $request_id;
 
-	# the incoming header is a hex string -> use it
-	"~^[0-9a-fA-F]{1,32}$" $http_x_tracing_id;
+	# the incoming header is a hex string with length 32 -> use it
+	"~^[0-9a-fA-F]{32}$" $http_x_tracing_id;
 
 	# fallthrough: incoming header is set but not a hex string -> use hardcoded string to make it clear something happened
-	default "invalid";
+	default "00000000000000000000000000000000";
 }

--- a/containers/proxy/config/conf.d/tracing.conf
+++ b/containers/proxy/config/conf.d/tracing.conf
@@ -7,7 +7,7 @@ map $http_x_tracing_id $traceId {
 	"" $request_id;
 
 	# the incoming header is a hex string -> use it
-	"~^[0-9a-fA-F]+$" $http_x_tracing_id;
+	"~^[0-9a-fA-F]{1,32}$" $http_x_tracing_id;
 
 	# fallthrough: incoming header is set but not a hex string -> use hardcoded string to make it clear something happened
 	default "invalid";


### PR DESCRIPTION
This is a security improvement to prevent injection attacks using the
tracing header.

An incoming tracing header *must* be a hexadecimal string (0-9,a-f) or
else it will be rejected and replaced by the hardcoded string `invalid`.

The requestID generated by nginx is hex as well.