### PR TITLE
PATCH: ignore major version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,9 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major" ]
     schedule:
       interval: "daily"
       time: "07:00"
@@ -12,6 +15,9 @@ updates:
       interval: "daily"
       time: "07:00"
     open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major" ]
     target-branch: main
     reviewers:
       - nlx-sascha
@@ -25,6 +31,9 @@ updates:
       interval: "daily"
       time: "07:00"
     open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major" ]
     target-branch: main
     reviewers:
       - nlx-sascha
@@ -38,6 +47,9 @@ updates:
       interval: "daily"
       time: "07:00"
     open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major" ]
     target-branch: main
     reviewers:
       - nlx-sascha
@@ -51,6 +63,9 @@ updates:
       interval: "daily"
       time: "07:00"
     open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major" ]
     target-branch: main
     reviewers:
       - nlx-sascha
@@ -62,6 +77,9 @@ updates:
       interval: "daily"
       time: "07:00"
     open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major" ]
     target-branch: main
     reviewers:
       - nlx-sascha
@@ -75,6 +93,9 @@ updates:
       interval: "daily"
       time: "07:00"
     open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major" ]
     target-branch: main
     reviewers:
       - nlx-sascha
@@ -88,6 +109,9 @@ updates:
       interval: "daily"
       time: "07:00"
     open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major" ]
     target-branch: main
     reviewers:
       - nlx-sascha
@@ -101,6 +125,9 @@ updates:
       interval: "daily"
       time: "07:00"
     open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major" ]
     target-branch: main
     reviewers:
       - nlx-sascha


### PR DESCRIPTION
This adds an ignore rule for all packages that disables major version updates. These updates are usually breaking and should never be done automatically.