### PR TITLE
FEATURE: Use utf8mb4 as default charset for new mysql databases

### DIFF
--- a/containers/mariadb/config/mysqld.cnf
+++ b/containers/mariadb/config/mysqld.cnf
@@ -62,3 +62,12 @@ tmp_table_size = 48M
 #user = mysql
 #userstat = 1
 wait_timeout = 60
+collation-server = utf8mb4_unicode_ci
+init-connect='SET NAMES utf8mb4'
+character-set-server = utf8mb4
+
+[client]
+default-character-set=utf8mb4
+
+[mysql]
+default-character-set=utf8mb4

--- a/containers/mysql/config/mysqld.cnf
+++ b/containers/mysql/config/mysqld.cnf
@@ -59,3 +59,12 @@ tmp_table_size = 48M
 #user = mysql
 #userstat = 1
 wait_timeout = 60
+collation-server = utf8mb4_unicode_ci
+init-connect='SET NAMES utf8mb4'
+character-set-server = utf8mb4
+
+[client]
+default-character-set=utf8mb4
+
+[mysql]
+default-character-set=utf8mb4


### PR DESCRIPTION
This feature allows us to use the MYSQL_DATABASE env variable to create new database with the correct charset.