### PR TITLE
[SHOPWARE-27] Without this file we get the following error: "Symbolic…

### DIFF
--- a/containers/webserver/config/shopware/default.conf
+++ b/containers/webserver/config/shopware/default.conf
@@ -5,7 +5,7 @@
 
 	DocumentRoot /var/www
 	<Directory /var/www/>
-		Options +ExecCGI +FollowSymlinks -SymLinksIfOwnerMatch
+		Options -Indexes +FollowSymLinks -SymLinksIfOwnerMatch -MultiViews
 		AllowOverride All
 		Require all granted
 		FileETag MTime Size

--- a/containers/webserver/config/shopware/default.conf
+++ b/containers/webserver/config/shopware/default.conf
@@ -5,7 +5,7 @@
 
 	DocumentRoot /var/www
 	<Directory /var/www/>
-		Options -Indexes +SymLinksIfOwnerMatch -MultiViews
+		Options +ExecCGI +FollowSymlinks -SymLinksIfOwnerMatch
 		AllowOverride All
 		Require all granted
 		FileETag MTime Size


### PR DESCRIPTION
… link not allowed or link target not accessible" in backend

This fix is from https://unix.stackexchange.com/questions/20993/symbolic-link-not-allowed-or-link-target-not-accessible-apache-on-centos-6