### PR TITLE
FEATURE: Install php sqlite3 extension in dev php container

### DIFF
--- a/containers/php/Dockerfile
+++ b/containers/php/Dockerfile
@@ -135,7 +135,7 @@ ENV PHP_IDE_CONFIG="serverName=localhost"
 
 RUN apt-get update && \
     apt-get -y install --no-install-suggests --no-install-recommends \
-      make php${PHP_VERSION}-dev php-pear openssh-client git patch \
+      make php${PHP_VERSION}-dev php${PHP_VERSION}-sqlite3 php-pear openssh-client git patch \
     && mkdir -p /tmp/pear/cache \
     && pecl channel-update pecl.php.net \
     && pecl install xdebug-3.1.5 \


### PR DESCRIPTION
When running functional tests in development, sqlite may be needed for a temporary database.