### PR TITLE
[BUGFIX] Fix logfile option in redis.conf

### DIFF
--- a/containers/redis/redis.conf
+++ b/containers/redis/redis.conf
@@ -169,7 +169,7 @@ loglevel notice
 # Specify the log file name. Also the empty string can be used to force
 # Redis to log on the standard output. Note that if you use standard
 # output for logging but daemonize, logs will be sent to /dev/null
-logfile
+logfile ""
 
 # To enable logging to the system logger, just set 'syslog-enabled' to yes,
 # and optionally update the other syslog parameters to suit your needs.


### PR DESCRIPTION
The missing empty string (no string != empty string) causes mayhem in our docker setups