### PR TITLE
BUGFIX: Ensure tideways is installed with a separate command to ensure install order with PHP v8.1 is handled correctly

### DIFF
--- a/containers/php/Dockerfile
+++ b/containers/php/Dockerfile
@@ -59,6 +59,7 @@ RUN apt-get update && \
         php${PHP_VERSION}-xml \
         php${PHP_VERSION}-yaml \
         php${PHP_VERSION}-zip \
+    && apt-get -y install --no-install-suggests --no-install-recommends \
         tideways-php \
         tideways-cli \
     && apt-get autoremove \


### PR DESCRIPTION
Currently, tideways does not work with PHP v8.1 because tideways-php is installed in the wrong order and thus no symlink is set to the shared object for the PHP extension. To ensure that tideways installs correctly with PHP v8.1, we move the installation of tideways to a separate command.