### PR TITLE
FEATURE: Split up mariadb docker file

### DIFF
--- a/.github/dependabot.template.yml
+++ b/.github/dependabot.template.yml
@@ -18,6 +18,22 @@ updates:
       time: "07:00"
     ignore:
       - dependency-name: "*"
+        update-types: [ "version-update:semver-patch" ]
+    target-branch: main
+    reviewers:
+      - nlx-sascha
+      - nlx-lars
+      - nlx-klein
+    labels:
+      - dependencies
+
+  - package-ecosystem: 'docker'
+    directory: '/*/Dockerfile'
+    schedule:
+      interval: "daily"
+      time: "07:00"
+    ignore:
+      - dependency-name: "*"
         update-types: [ "version-update:semver-major" ]
     target-branch: main
     reviewers:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -56,20 +56,22 @@ jobs:
         image:
           - name: mariadb
             context: ./mariadb
-            target: 'mariadb'
-            version: '10.10'
+            target: ''
+            version: ''
             build-args: ''
             spec-file: ''
           - name: mariadb
             context: ./mariadb
-            target: 'mariadb_106'
-            version: '10.6'
+            target: ''
+            version: ''
+            file: 10.6.dockerfile
             build-args: ''
             spec-file: ''
           - name: mariadb
             context: ./mariadb
-            target: 'mariadb_103'
-            version: '10.3'
+            target: ''
+            version: ''
+            file: 10.3.dockerfile
             build-args: ''
             spec-file: ''
           - name: mysql

--- a/mariadb/10.3.Dockerfile
+++ b/mariadb/10.3.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
-# This is always the latest
-FROM mariadb:10.11.2 as mariadb
+# Version of Ubuntu 20.04
+FROM mariadb:10.3.37 as mariadb
 
 COPY config /etc/mysql/conf.d
 HEALTHCHECK --interval=2s --timeout=20s --retries=10 CMD mysqladmin ping -h localhost -u root -p$MYSQL_ROOT_PASSWORD

--- a/mariadb/10.6.Dockerfile
+++ b/mariadb/10.6.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
-# This is always the latest
-FROM mariadb:10.11.2 as mariadb
+# Version of Ubuntu 22.04
+FROM mariadb:10.6.11 as mariadb
 
 COPY config /etc/mysql/conf.d
 HEALTHCHECK --interval=2s --timeout=20s --retries=10 CMD mysqladmin ping -h localhost -u root -p$MYSQL_ROOT_PASSWORD


### PR DESCRIPTION
This allows us to tune dependabot version updates to patch level for ubuntu release versions.