### PR TITLE
BUGFIX: Redirect to styleguide ui if path is not branches or releases

### DIFF
--- a/styleguide/etc/nginx/conf.d/default.conf
+++ b/styleguide/etc/nginx/conf.d/default.conf
@@ -52,4 +52,8 @@ server {
             allow all;
         }
     }
+
+    location ~ ^(?!/(?:branches|releases)) {
+        return 302 /branches/master;
+    }
 }


### PR DESCRIPTION
When accessing the styleguide directly, the path /branches/(version) must be given, otherwise a 403 forbidden is thrown.