### PR TITLE
feat: Add Dutch and Portuguese locales to PHP Dockerfiles

### DIFF
--- a/php/8.2.dockerfile
+++ b/php/8.2.dockerfile
@@ -35,6 +35,8 @@ RUN locale-gen de_DE.UTF-8 && \
     locale-gen en_US.UTF-8 && \
     locale-gen es_ES.UTF-8 && \
     locale-gen fr_FR.UTF-8 && \
+    locale-gen nl_NL.UTF-8 && \
+    locale-gen pt_PT.UTF-8 && \
     locale-gen it_IT.UTF-8
 
 # Install dev certificates

--- a/php/8.3.dockerfile
+++ b/php/8.3.dockerfile
@@ -35,6 +35,8 @@ RUN locale-gen de_DE.UTF-8 && \
     locale-gen en_US.UTF-8 && \
     locale-gen es_ES.UTF-8 && \
     locale-gen fr_FR.UTF-8 && \
+    locale-gen nl_NL.UTF-8 && \
+    locale-gen pt_PT.UTF-8 && \
     locale-gen it_IT.UTF-8
 
 # Install dev certificates

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -31,6 +31,8 @@ RUN locale-gen de_DE.UTF-8 && \
     locale-gen en_US.UTF-8 && \
     locale-gen es_ES.UTF-8 && \
     locale-gen fr_FR.UTF-8 && \
+    locale-gen nl_NL.UTF-8 && \
+    locale-gen pt_PT.UTF-8 && \
     locale-gen it_IT.UTF-8
 
 # Install dev certificates


### PR DESCRIPTION
The Dutch (nl_NL.UTF-8) and Portuguese (pt_PT.UTF-8) locales have been added to the PHP Dockerfiles. This addition is expected to enhance the current localization support for the involved PHP versions in containers.