### PR TITLE
BUGFIX: Set php-pfm log_level to waring instead of notice

### DIFF
--- a/php/config/fpm/pool.d/docker.conf
+++ b/php/config/fpm/pool.d/docker.conf
@@ -4,6 +4,7 @@ error_log = /proc/self/fd/2
 
 ; https://github.com/docker-library/php/pull/725#issuecomment-443540114
 log_limit = 8192
+log_level = warning
 
 [www]
 


### PR DESCRIPTION
Notice setting is very spammy