### PR TITLE
FIX: Prevent healthcheck error without defining a user

### DIFF
--- a/postgres/14.dockerfile
+++ b/postgres/14.dockerfile
@@ -5,4 +5,4 @@ ENV TZ="Europe/Berlin"
 
 COPY config /etc/postgresql
 
-HEALTHCHECK --interval=2s --timeout=5s --retries=10 CMD pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}
+HEALTHCHECK --interval=2s --timeout=5s --retries=10 CMD pg_isready -U $POSTGRES_USER -d $POSTGRES_DB

--- a/postgres/14.dockerfile
+++ b/postgres/14.dockerfile
@@ -5,4 +5,4 @@ ENV TZ="Europe/Berlin"
 
 COPY config /etc/postgresql
 
-HEALTHCHECK --interval=2s --timeout=5s --retries=10 CMD pg_isready
+HEALTHCHECK --interval=2s --timeout=5s --retries=10 CMD pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}

--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -5,4 +5,4 @@ ENV TZ="Europe/Berlin"
 
 COPY config /etc/postgresql
 
-HEALTHCHECK --interval=2s --timeout=5s --retries=10 CMD pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}
+HEALTHCHECK --interval=2s --timeout=5s --retries=10 CMD pg_isready -U $POSTGRES_USER -d $POSTGRES_DB

--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -5,4 +5,4 @@ ENV TZ="Europe/Berlin"
 
 COPY config /etc/postgresql
 
-HEALTHCHECK --interval=2s --timeout=5s --retries=10 CMD pg_isready
+HEALTHCHECK --interval=2s --timeout=5s --retries=10 CMD pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}


### PR DESCRIPTION
At the moment I get the error "Error FATAL: role "root" does not exist" after starting database container. To fix that we need to define the postgres user.

The fix is from here https://github.com/peter-evans/docker-compose-healthcheck/issues/16#issuecomment-1073039761

Related: CRM-677