### PR TITLE
FEAT: Add postgres 12 for orocrm project

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -98,6 +98,13 @@ jobs:
             file: 14.dockerfile
             build-args: ''
             spec-file: ''
+          - name: postgres
+            context: ./postgres
+            target: ''
+            version: ''
+            file: 12.dockerfile
+            build-args: ''
+            spec-file: ''
           - name: proxy
             context: ./proxy
             target: ''

--- a/postgres/12.dockerfile
+++ b/postgres/12.dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM postgres:12.6 AS database
+FROM postgres:12.18 AS database
 
 ENV TZ="Europe/Berlin"
 

--- a/postgres/12.dockerfile
+++ b/postgres/12.dockerfile
@@ -1,0 +1,8 @@
+# syntax=docker/dockerfile:1
+FROM postgres:12.6 AS database
+
+ENV TZ="Europe/Berlin"
+
+COPY config /etc/postgresql
+
+HEALTHCHECK --interval=2s --timeout=5s --retries=10 CMD pg_isready -U $POSTGRES_USER -d $POSTGRES_DB


### PR DESCRIPTION
In oroCRM 4.2 we need postgres 12

Related: CRM-788