### PR TITLE
fix: Set env variable for hostname argument of tideways daemon

### DIFF
--- a/tideways-daemon/Dockerfile
+++ b/tideways-daemon/Dockerfile
@@ -2,6 +2,7 @@
 FROM debian:bookworm-slim AS tideways-daemon
 
 ENV TIDEWAYS_ENVIRONMENT=production \
+    TIDEWAYS_HOSTNAME=tideways-daemon \
     TIDEWAYS_VERSION=1.8.42
 
 RUN useradd --system tideways
@@ -19,4 +20,4 @@ EXPOSE 9135
 
 USER tideways
 
-ENTRYPOINT ["tideways-daemon", "--hostname=tideways-daemon", "--address=0.0.0.0:9135"]
+ENTRYPOINT ["tideways-daemon", "--hostname=${TIDEWAYS_HOSTNAME}", "--address=0.0.0.0:9135"]


### PR DESCRIPTION
The new daemon version only adds the container id of the running daemon to the hostname. This results in something like
tideways-daemon#4bae42711daa, which is not working for us. After deployments on live and staging, a new tideways-daemon found its way into the list of servers in tideways with a new hostname which resulted in a total of 32 servers for the related project.

