### PR TITLE
fix: set stopsignal to SIGTERM

### DIFF
--- a/php/8.2.Dockerfile
+++ b/php/8.2.Dockerfile
@@ -130,7 +130,7 @@ FROM base AS php-fpm
 
 COPY fpm /usr/local/bin/
 
-STOPSIGNAL SIGQUIT
+STOPSIGNAL SIGTERM
 EXPOSE 9000
 
 HEALTHCHECK --interval=2s --timeout=5s --retries=10 CMD php-fpm-healthcheck || exit 1

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -126,7 +126,7 @@ FROM base AS php-fpm
 
 COPY fpm /usr/local/bin/
 
-STOPSIGNAL SIGQUIT
+STOPSIGNAL SIGTERM
 EXPOSE 9000
 
 HEALTHCHECK --interval=2s --timeout=5s --retries=10 CMD php-fpm-healthcheck || exit 1


### PR DESCRIPTION
The SIGTERM allows to safe shutdown processes.

Symfony example https://symfony.com/doc/current/messenger.html#graceful-shutdown