### PR TITLE
fix: use SIGTERM for cli and SIGQUIT for fpm

### DIFF
--- a/php/8.2.Dockerfile
+++ b/php/8.2.Dockerfile
@@ -130,7 +130,7 @@ FROM base AS php-fpm
 
 COPY fpm /usr/local/bin/
 
-STOPSIGNAL SIGTERM
+STOPSIGNAL SIGQUIT
 EXPOSE 9000
 
 HEALTHCHECK --interval=2s --timeout=5s --retries=10 CMD php-fpm-healthcheck || exit 1
@@ -138,6 +138,8 @@ ENTRYPOINT ["docker-php-entrypoint"]
 CMD ["php-fpm"]
 
 FROM base AS php-cli
+
+STOPSIGNAL SIGTERM
 
 ENV PHP_MEMORY_LIMIT=-1 \
     PHP_MAX_EXECUTION_TIME=-1
@@ -205,6 +207,8 @@ COPY dev/scripts /usr/local/bin/
 
 # Dev PHP cli
 FROM php-fpm-dev AS php-cli-dev
+
+STOPSIGNAL SIGTERM
 
 ENV PHP_MEMORY_LIMIT=-1
 ENV PHP_MAX_EXECUTION_TIME=-1

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -135,6 +135,8 @@ CMD ["php-fpm"]
 
 FROM base AS php-cli
 
+STOPSIGNAL SIGTERM
+
 ENV PHP_MEMORY_LIMIT=-1 \
     PHP_MAX_EXECUTION_TIME=-1
 
@@ -202,6 +204,8 @@ COPY dev/scripts /usr/local/bin/
 
 # Dev PHP cli
 FROM php-fpm-dev AS php-cli-dev
+
+STOPSIGNAL SIGTERM
 
 ENV PHP_MEMORY_LIMIT=-1
 ENV PHP_MAX_EXECUTION_TIME=-1


### PR DESCRIPTION
FPM needs SIGQUIT to graceful stop: https://linux.die.net/man/8/php-fpm

Symfony messenger-consume needs SIGTERM to graceful stop: https://symfony.com/doc/current/messenger.html#graceful-shutdown

From Symfony 7.1 we can switch to SIGQUIT: https://symfony.com/blog/new-in-symfony-7-1-posix-signals-improvements#handle-sigquit-signal-in-console-and-messenger