### PR TITLE
Added support for Node.js version 22

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -36,6 +36,9 @@ jobs:
         - version: 20
           build-args: |
             NODE_VERSION=20
+        - version: 22
+          build-args: |
+            NODE_VERSION=22
 
     steps:
       - name: Checkout

--- a/build-container.sh
+++ b/build-container.sh
@@ -87,3 +87,4 @@ docker buildx build -t ghcr.io/netlogix/docker/php-supervisor:8.4 --build-arg PH
 
 docker buildx build -t ghcr.io/netlogix/docker/node:18 --build-arg NODE_VERSION=18 -f node/Dockerfile node
 docker buildx build -t ghcr.io/netlogix/docker/node:20 --build-arg NODE_VERSION=20 -f node/Dockerfile node
+docker buildx build -t ghcr.io/netlogix/docker/node:22 --build-arg NODE_VERSION=22 -f node/Dockerfile node

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG NODE_VERSION=20
+ARG NODE_VERSION=22
 FROM node:${NODE_VERSION}-slim AS node
 
 # Install dev certificates


### PR DESCRIPTION
This pull request includes updates to the Docker configurations for Node.js.

### Node.js Updates:
* Added support for Node.js version 22 in `.github/workflows/node.yml` and `build-container.sh`. (`[[1]](diffhunk://#diff-4e88a8cc63d2540befa3412886ac9b9db5cd10bce852960298517ea4bd7f7bb7R39-R41)`, `[[2]](diffhunk://#diff-850c1b0509e939369aab134659edfa4c42d50a39cbe5978352ed7d4d41551003R80-R90)`)
* Updated the default `NODE_VERSION` to 22 in `node/Dockerfile`. (`[node/DockerfileL2-R2](diffhunk://#diff-e3718e3964930481779418c2836c5afa460848f3e49a9800a78f35cf65ff0401L2-R2)`)