### PR TITLE
fix: CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,1 @@
-* @netlogix/devops
-* @saschanowak
-* @paxuclus
-* @nlx-klein
+* @netlogix/devops @saschanowak @paxuclus @nlx-klein


### PR DESCRIPTION
"If you want to match two or more code owners with the same pattern, all the code owners must be on the same line. If the code owners are not on the same line, the pattern matches only the last mentioned code owner."