### PR TITLE
feat: update solr to 9.9.0

### DIFF
--- a/build-container.sh
+++ b/build-container.sh
@@ -16,6 +16,7 @@ docker buildx build -t ghcr.io/netlogix/docker/styleguide:${VERSION} -f nginx/Do
 docker buildx build -t ghcr.io/netlogix/docker/rabbitmq:${VERSION} -f rabbitmq/Dockerfile rabbitmq
 docker buildx build -t ghcr.io/netlogix/docker/redis:${VERSION} -f redis/Dockerfile redis
 docker buildx build -t ghcr.io/netlogix/docker/solr:${VERSION} -f solr/Dockerfile solr
+docker buildx build -t ghcr.io/netlogix/docker/solr:8.11 -f solr/8.Dockerfile solr
 docker buildx build -t ghcr.io/netlogix/docker/varnish:${VERSION} -f varnish/Dockerfile varnish
 docker buildx build -t ghcr.io/netlogix/docker/elasticsearch:${VERSION} -f elasticsearch/Dockerfile elasticsearch
 docker buildx build -t ghcr.io/netlogix/docker/httpd-neos:${VERSION} -f httpd/Dockerfile --target=httpd-neos httpd

--- a/solr/8.Dockerfile
+++ b/solr/8.Dockerfile
@@ -1,33 +1,42 @@
 # syntax=docker/dockerfile:1
-FROM solr:8.11.3 AS builder
+FROM solr:8.11.4 AS builder
 
-ENV TYPO3_SOLR=11.5.0 \
-    TYPO3_SOLR_DOWNLOAD_SHA512="a0c0181993606dbaa587520e8aa8988f1b0eb845215828cf31df0dc181497ab4932db03359bc89655366197247210b4a82cbba1b7bcc5abba85545811e17eefe"
+ENV TYPO3_SOLR=11.5.7 \
+    TYPO3_SOLR_DOWNLOAD_SHA512="11dadce1b557a00b7b726aa9279120637f49d4377c3d7260eb252f9f4fece8f7e30bbe640df24dbe7e085b7422b3e1b1bdd08d268cf044ea39563288001b78ee"
 
 USER root
-RUN set -ex; \
-    apt-get update; \
-    apt-get -y install wget unzip; \
-    SOLR_DOWNLOAD_URL="https://github.com/TYPO3-Solr/ext-solr/releases/download/$TYPO3_SOLR/solr_$TYPO3_SOLR.zip"; \
-    wget -t 10 --max-redirect 4 --retry-connrefused -nv "$SOLR_DOWNLOAD_URL" -O "/tmp/solr.zip"; \
-    echo "$TYPO3_SOLR_DOWNLOAD_SHA512 /tmp/solr.zip" | sha512sum -c -; \
-    unzip /tmp/solr.zip -d /tmp/solr;
+RUN apt-get update && \
+    apt-get -y install wget tar && \
+    SOLR_DOWNLOAD_URL="https://github.com/TYPO3-Solr/ext-solr/archive/${TYPO3_SOLR}.tar.gz" && \
+    wget -t 10 --max-redirect 4 --retry-connrefused -nv "$SOLR_DOWNLOAD_URL" -O "/tmp/solr.tar.gz" && \
+    sha512sum /tmp/solr.tar.gz && \
+    echo "$TYPO3_SOLR_DOWNLOAD_SHA512 /tmp/solr.tar.gz" | sha512sum -c - && \
+    mkdir -p /tmp/solr && \
+    tar -zxvf /tmp/solr.tar.gz -C /tmp/solr --strip-components=1;
 
 RUN sed -i "s|name=core_|name=website-|i" /tmp/solr/Resources/Private/Solr/cores/*/core.properties \
     && cd /tmp/solr/Resources/Private/Solr/configsets/ext_solr_11_5_0/conf \
     && for f in _schema_analysis_*_core_*.json; do mv "$f" "$(echo "$f" | sed s/core_/website-/)"; done
 
-FROM solr:8.11.3 AS solr
-
-ENV SOLR_LOG_LEVEL=WARN \
+FROM solr:8.11.4 AS solr
+ENV TERM=linux \
+    SOLR_LOG_LEVEL=WARN \
     SOLR_PORT=8983 \
     HEALTHCHECK_CORE=website-generic
 
+ARG SOLR_UNIX_UID="8983"
+ARG SOLR_UNIX_GID="8983"
+
 USER root
-RUN rm -fR /opt/solr/server/solr/*
+RUN rm -fR /opt/solr/server/solr/* \
+  && usermod --non-unique --uid "${SOLR_UNIX_UID}" solr \
+  && groupmod --non-unique --gid "${SOLR_UNIX_GID}" solr \
+  && chown -R solr:solr /var/solr /opt/solr \
+  && apt update && apt upgrade -y && apt install sudo -y
+
 USER solr
 
-COPY --from=builder --chown=solr:solr /tmp/solr/Resources/Private/Solr /var/solr/data
+COPY --from=builder --chown=solr:solr /tmp/solr/Resources/Private/Solr/ /var/solr/data
 RUN mkdir -p /var/solr/data/data
 
 HEALTHCHECK --interval=2s --timeout=20s --retries=10 CMD curl -s -A 'healthcheck' http://localhost:$SOLR_PORT/solr/$HEALTHCHECK_CORE/admin/ping?wt=json | grep -q '"status":"OK"'

--- a/solr/Dockerfile
+++ b/solr/Dockerfile
@@ -1,8 +1,8 @@
 # syntax=docker/dockerfile:1
-FROM solr:9.7.0 AS builder
+FROM solr:9.9.0 AS builder
 
-ENV TYPO3_SOLR=12.0.3 \
-    TYPO3_SOLR_DOWNLOAD_SHA512="882f24a44d221f5d85a2066ab1235c9aedcd31c8a8f2009f9343b73de2931fd354fed6a8175fe18fa6fa0c284dd07d428c4f547f24875129e5a1d57c5ffd283f"
+ENV TYPO3_SOLR=13.0.3 \
+    TYPO3_SOLR_DOWNLOAD_SHA512="34a9743d5c96b6554eb281fcaa01e4e1946c217f5d1a7c99821b2236dd03c67aada0fb19ef380f64100acb7cabbc62822bddae9d3d0b3131c9ebb4b50f3ff847"
 
 USER root
 
@@ -15,7 +15,7 @@ RUN apt-get update && \
     mkdir -p /tmp/solr && \
     tar -zxvf /tmp/solr.tar.gz -C /tmp/solr --strip-components=1;
 
-FROM solr:9.6.1 AS solr
+FROM solr:9.9.0 AS solr
 ENV TERM=linux \
     SOLR_LOG_LEVEL=WARN \
     SOLR_PORT=8983 \
@@ -29,11 +29,7 @@ RUN rm -fR /opt/solr/server/solr/* \
   && usermod --non-unique --uid "${SOLR_UNIX_UID}" solr \
   && groupmod --non-unique --gid "${SOLR_UNIX_GID}" solr \
   && chown -R solr:solr /var/solr /opt/solr \
-  && apt update && apt upgrade -y && apt install sudo -y \
-  && echo "# EXT:solr relevant changes: " >> /etc/default/solr.in.sh \
-    && echo "SOLR_ENABLE_REMOTE_STREAMING=true" >> /etc/default/solr.in.sh \
-    && echo "SOLR_ENABLE_STREAM_BODY=true" >> /etc/default/solr.in.sh \
-    && echo "# END: EXT:solr" >> /etc/default/solr.in.sh
+  && apt update && apt upgrade -y && apt install sudo -y
 
 USER solr
 


### PR DESCRIPTION
This pull request updates the Solr Docker images to use newer Solr and TYPO3 Solr extension versions, introduces a dedicated build for Solr 8.11, and improves the Dockerfiles for maintainability and security. The changes ensure compatibility with the latest features and security updates, and streamline the Solr image build process.

**Solr Docker image updates:**

* Upgraded the main Solr Dockerfile from Solr 9.7.0 to 9.9.0 and updated the TYPO3 Solr extension from 12.0.3 to 13.0.3, along with its SHA512 checksum.
* Updated the Solr 8 Dockerfile from Solr 8.11.3 to 8.11.4 and the TYPO3 Solr extension from 11.5.0 to 11.5.7, with the corresponding SHA512 checksum.

**Build process improvements:**

* Added a new build command in `build-container.sh` for the Solr 8.11 image, using the dedicated `solr/8.Dockerfile`.
* Changed the Solr 8 Dockerfile to use tarballs instead of zip files for the TYPO3 Solr extension, updated dependencies, and improved file extraction and verification steps.

**Security and configuration:**

* Standardized user and group IDs for the Solr user, and ensured correct ownership and permissions of relevant directories in both Dockerfiles. [[1]](diffhunk://#diff-410e1bd7c626dc394a3e29c8eb5c09ae56322c91a2e17e7fa551b2ee9d9613a7L2-R39) [[2]](diffhunk://#diff-ab11c2730ab127a0b39455d52ee5fbe9a39a07e14dcf12df034e5979e2b38d49L18-R18)
* Removed redundant or unnecessary configuration modifications in the main Solr Dockerfile for clarity and maintainability.