### PR TITLE
Remove EXPOSE for port 9145 in Dockerfile

### DIFF
--- a/prometheus-nginx-exporter/Dockerfile
+++ b/prometheus-nginx-exporter/Dockerfile
@@ -19,5 +19,4 @@ COPY --from=builder /out/* /
 # Run as non-root user for secure environments
 USER 59000:59000
 
-EXPOSE 9145
 ENTRYPOINT [ "/nginx_exporter" ]


### PR DESCRIPTION
Remove EXPOSE directive for port 9145 in Dockerfile.

If you want to run this exporter container multiple times, e.g. in an multi docker compose setup or with multiple nginx instances as proxy and webserver, this port will always be exposed. The prometheus takes the first located port in service discovery, therefore the target is down and no metrics are collected.