### PR TITLE
Remove EXPOSE directive for port 9253 in Dockerfile.

### DIFF
--- a/prometheus-php-fpm-exporter/Dockerfile
+++ b/prometheus-php-fpm-exporter/Dockerfile
@@ -19,5 +19,4 @@ COPY --from=builder /out/* /
 # Run as non-root user for secure environments
 USER 59000:59000
 
-EXPOSE 9253
 ENTRYPOINT [ "/php-fpm_exporter", "server" ]


### PR DESCRIPTION
If you want to run this exporter container multiple times, e.g. in an multi docker compose setup or with multiple php-fpm instances, this port will always be exposed. 

Prometheus takes the first located port in service discovery, therefore the target is down and no metrics are collected.