### PR TITLE
Add 'stable' tag to Chromium Docker image

### DIFF
--- a/.github/workflows/chromium.yml
+++ b/.github/workflows/chromium.yml
@@ -51,7 +51,7 @@ jobs:
           target: chromium
           file: ./chromium/Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ghcr.io/netlogix/docker/chromium:latest
+          tags: ghcr.io/netlogix/docker/chromium:latest,ghcr.io/netlogix/docker/chromium:stable
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha, mode=max


### PR DESCRIPTION
Add 'stable' tag again, as most projects use the stable tag instead of the latest tag (https://github.com/netlogix/docker/pkgs/container/docker%2Fchromium)