### PR TITLE
feat: Improve FrankenPHP container

### DIFF
--- a/.github/workflows/frankenphp.yml
+++ b/.github/workflows/frankenphp.yml
@@ -95,6 +95,21 @@ jobs:
           cache-from: type=gha, scope=${{ github.workflow }}-frankenphp
           cache-to: type=gha, scope=${{ github.workflow }}-frankenphp, mode=max
 
+      - name: Build and push (frankenphp-cron)
+        uses: docker/build-push-action@v7
+        timeout-minutes: 120
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: ./php
+          target: frankenphp-cron
+          file: ./php/${{ matrix.image.file || 'Dockerfile' }}
+          build-args: ${{ matrix.image.build-args }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ghcr.io/netlogix/docker/frankenphp-cron:${{ matrix.image.version }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha, scope=${{ github.workflow }}-frankenphp
+          cache-to: type=gha, scope=${{ github.workflow }}-frankenphp, mode=max
+
   build-docker-dev-image:
     name: 'Build frankenphp-${{ matrix.image.version }}-dev docker image'
     runs-on: ubuntu-latest
@@ -164,3 +179,18 @@ jobs:
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha, scope=${{ github.workflow }}-frankenphp-dev
           cache-to: type=gha, scope=${{ github.workflow }}-frankenphp-dev, mode=max
+
+      - name: Build and push (frankenphp-cron-dev)
+        uses: docker/build-push-action@v7
+        timeout-minutes: 120
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: ./php
+          target: frankenphp-cron-dev
+          file: ./php/${{ matrix.image.file || 'Dockerfile' }}
+          build-args: ${{ matrix.image.build-args }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ghcr.io/netlogix/docker/frankenphp-cron-dev:${{ matrix.image.version }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha, scope=${{ github.workflow }}-frankenphp-dev
+          cache-to: type=gha, scope=${{ github.workflow }}-frankenphp-dev, mode=max)

--- a/build-container.sh
+++ b/build-container.sh
@@ -41,33 +41,12 @@ docker buildx build -t ghcr.io/netlogix/docker/prometheus-redis-exporter:${VERSI
 docker buildx build -t ghcr.io/netlogix/docker/prometheus-solr-exporter:${VERSION} -f prometheus-solr-exporter/Dockerfile prometheus-solr-exporter
 docker buildx build -t ghcr.io/netlogix/docker/prometheus-varnish-exporter:${VERSION} -f prometheus-varnish-exporter/Dockerfile prometheus-varnish-exporter
 
-docker buildx build -t ghcr.io/netlogix/docker/php-fpm:7.2 --build-arg PHP_VERSION=7.2 --build-arg UBUNTU_VERSION=24.04 -f php/7.x.Dockerfile --target=php-fpm php
-docker buildx build -t ghcr.io/netlogix/docker/php-cli:7.2 --build-arg PHP_VERSION=7.2 --build-arg UBUNTU_VERSION=24.04 -f php/7.x.Dockerfile --target=php-cli php
-docker buildx build -t ghcr.io/netlogix/docker/php-fpm-dev:7.2 --build-arg PHP_VERSION=7.2 --build-arg UBUNTU_VERSION=24.04 -f php/7.x.Dockerfile --target=php-fpm-dev php
-docker buildx build -t ghcr.io/netlogix/docker/php-cli-dev:7.2 --build-arg PHP_VERSION=7.2 --build-arg UBUNTU_VERSION=24.04 -f php/7.x.Dockerfile --target=php-cli-dev php
-docker buildx build -t ghcr.io/netlogix/docker/php-cron:7.2 --build-arg PHP_VERSION=7.2 --build-arg UBUNTU_VERSION=24.04 -f php/7.x.Dockerfile --target=php-cron php
-docker buildx build -t ghcr.io/netlogix/docker/php-cron-dev:7.2 --build-arg PHP_VERSION=7.2 --build-arg UBUNTU_VERSION=24.04 -f php/7.x.Dockerfile --target=php-cron-dev php
-docker buildx build -t ghcr.io/netlogix/docker/php-supervisor:7.2 --build-arg PHP_VERSION=7.2 --build-arg UBUNTU_VERSION=24.04 -f php/7.x.Dockerfile --target=php-supervisor php
-
-docker buildx build -t ghcr.io/netlogix/docker/php-fpm:7.3 --build-arg PHP_VERSION=7.3 --build-arg UBUNTU_VERSION=24.04 -f php/7.x.Dockerfile --target=php-fpm php
-docker buildx build -t ghcr.io/netlogix/docker/php-cli:7.3 --build-arg PHP_VERSION=7.3 --build-arg UBUNTU_VERSION=24.04 -f php/7.x.Dockerfile --target=php-cli php
-docker buildx build -t ghcr.io/netlogix/docker/php-fpm-dev:7.3 --build-arg PHP_VERSION=7.3 --build-arg UBUNTU_VERSION=24.04 -f php/7.x.Dockerfile --target=php-fpm-dev php
-docker buildx build -t ghcr.io/netlogix/docker/php-cli-dev:7.3 --build-arg PHP_VERSION=7.3 --build-arg UBUNTU_VERSION=24.04 -f php/7.x.Dockerfile --target=php-cli-dev php
-docker buildx build -t ghcr.io/netlogix/docker/php-cron:7.3 --build-arg PHP_VERSION=7.3 --build-arg UBUNTU_VERSION=24.04 -f php/7.x.Dockerfile --target=php-cron php
-docker buildx build -t ghcr.io/netlogix/docker/php-cron-dev:7.3 --build-arg PHP_VERSION=7.3 --build-arg UBUNTU_VERSION=24.04 -f php/7.x.Dockerfile --target=php-cron-dev php
-docker buildx build -t ghcr.io/netlogix/docker/php-supervisor:7.3 --build-arg PHP_VERSION=7.3 --build-arg UBUNTU_VERSION=24.04 -f php/7.x.Dockerfile --target=php-supervisor php
-
-docker buildx build -t ghcr.io/netlogix/docker/php-fpm:7.4 --build-arg PHP_VERSION=7.4 --build-arg UBUNTU_VERSION=20.04 -f php/7.x.Dockerfile --target=php-fpm php
-docker buildx build -t ghcr.io/netlogix/docker/php-cli:7.4 --build-arg PHP_VERSION=7.4 --build-arg UBUNTU_VERSION=20.04 -f php/7.x.Dockerfile --target=php-cli php
-docker buildx build -t ghcr.io/netlogix/docker/php-fpm-dev:7.4 --build-arg PHP_VERSION=7.4 --build-arg UBUNTU_VERSION=20.04 -f php/7.x.Dockerfile --target=php-fpm-dev php
-docker buildx build -t ghcr.io/netlogix/docker/php-cli-dev:7.4 --build-arg PHP_VERSION=7.4 --build-arg UBUNTU_VERSION=20.04 -f php/7.x.Dockerfile --target=php-cli-dev php
-docker buildx build -t ghcr.io/netlogix/docker/php-cron:7.4 --build-arg PHP_VERSION=7.4 --build-arg UBUNTU_VERSION=20.04 -f php/7.x.Dockerfile --target=php-cron php
-docker buildx build -t ghcr.io/netlogix/docker/php-cron-dev:7.4 --build-arg PHP_VERSION=7.4 --build-arg UBUNTU_VERSION=20.04 -f php/7.x.Dockerfile --target=php-cron-dev php
-docker buildx build -t ghcr.io/netlogix/docker/php-supervisor:7.4 --build-arg PHP_VERSION=7.4 --build-arg UBUNTU_VERSION=20.04 -f php/7.x.Dockerfile --target=php-supervisor php
-
 docker buildx build -t ghcr.io/netlogix/docker/php-fpm:8.0 --build-arg PHP_VERSION=8.0 --build-arg UBUNTU_VERSION=24.04 -f php/8.x.Dockerfile --target=php-fpm php
 docker buildx build -t ghcr.io/netlogix/docker/php-cli:8.0 --build-arg PHP_VERSION=8.0 --build-arg UBUNTU_VERSION=24.04 -f php/8.x.Dockerfile --target=php-cli php
-docker buildx build -t ghcr.io/netlogix/docker/php-cron:8.0--build-arg PHP_VERSION=8.0 --build-arg UBUNTU_VERSION=24.04 -f php/8.x.Dockerfile --target=php-cron php
+docker buildx build -t ghcr.io/netlogix/docker/php-fpm-dev:8.0 --build-arg PHP_VERSION=8.0 --build-arg UBUNTU_VERSION=24.04 -f php/8.x.Dockerfile --target=php-fpm-dev php
+docker buildx build -t ghcr.io/netlogix/docker/php-cli-dev:8.0 --build-arg PHP_VERSION=8.0 --build-arg UBUNTU_VERSION=24.04 -f php/8.x.Dockerfile --target=php-cli-dev php
+docker buildx build -t ghcr.io/netlogix/docker/php-cron:8.0 --build-arg PHP_VERSION=8.0 --build-arg UBUNTU_VERSION=24.04 -f php/8.x.Dockerfile --target=php-cron php
+docker buildx build -t ghcr.io/netlogix/docker/php-cron-dev:8.0 --build-arg PHP_VERSION=8.0 --build-arg UBUNTU_VERSION=24.04 -f php/8.x.Dockerfile --target=php-cron-dev php
 docker buildx build -t ghcr.io/netlogix/docker/php-supervisor:8.0 --build-arg PHP_VERSION=8.0 --build-arg UBUNTU_VERSION=24.04 -f php/8.x.Dockerfile --target=php-supervisor php
 
 docker buildx build -t ghcr.io/netlogix/docker/php-fpm:8.1 --build-arg PHP_VERSION=8.1 --build-arg UBUNTU_VERSION=22.04 -f php/Dockerfile --target=php-fpm php
@@ -114,12 +93,24 @@ docker buildx build -t ghcr.io/netlogix/docker/frankenphp:8.3 --build-arg PHP_VE
 docker buildx build -t ghcr.io/netlogix/docker/frankenphp-dev:8.3 --build-arg PHP_VERSION=8.3 -f php/frankenphp.Dockerfile --target=frankenphp-dev php
 docker buildx build -t ghcr.io/netlogix/docker/frankenphp-cli:8.3 --build-arg PHP_VERSION=8.3 -f php/frankenphp.Dockerfile --target=frankenphp-cli php
 docker buildx build -t ghcr.io/netlogix/docker/frankenphp-cli-dev:8.3 --build-arg PHP_VERSION=8.3 -f php/frankenphp.Dockerfile --target=frankenphp-cli-dev php
+docker buildx build -t ghcr.io/netlogix/docker/frankenphp-cron:8.3 --build-arg PHP_VERSION=8.3 -f php/frankenphp.Dockerfile --target=frankenphp-cron php
+docker buildx build -t ghcr.io/netlogix/docker/frankenphp-cron-dev:8.3 --build-arg PHP_VERSION=8.3 -f php/frankenphp.Dockerfile --target=frankenphp-cron-dev php
 
 docker buildx build -t ghcr.io/netlogix/docker/frankenphp:8.4 --build-arg PHP_VERSION=8.4 -f php/frankenphp.Dockerfile --target=frankenphp php
 docker buildx build -t ghcr.io/netlogix/docker/frankenphp-dev:8.4 --build-arg PHP_VERSION=8.4 -f php/frankenphp.Dockerfile --target=frankenphp-dev php
 docker buildx build -t ghcr.io/netlogix/docker/frankenphp-cli:8.4 --build-arg PHP_VERSION=8.4 -f php/frankenphp.Dockerfile --target=frankenphp-cli php
 docker buildx build -t ghcr.io/netlogix/docker/frankenphp-cli-dev:8.4 --build-arg PHP_VERSION=8.4 -f php/frankenphp.Dockerfile --target=frankenphp-cli-dev php
+docker buildx build -t ghcr.io/netlogix/docker/frankenphp-cron:8.4 --build-arg PHP_VERSION=8.4 -f php/frankenphp.Dockerfile --target=frankenphp-cron php
+docker buildx build -t ghcr.io/netlogix/docker/frankenphp-cron-dev:8.4 --build-arg PHP_VERSION=8.4 -f php/frankenphp.Dockerfile --target=frankenphp-cron-dev php
+
+docker buildx build -t ghcr.io/netlogix/docker/frankenphp:8.5 --build-arg PHP_VERSION=8.5 -f php/frankenphp.Dockerfile --target=frankenphp php
+docker buildx build -t ghcr.io/netlogix/docker/frankenphp-dev:8.5 --build-arg PHP_VERSION=8.5 -f php/frankenphp.Dockerfile --target=frankenphp-dev php
+docker buildx build -t ghcr.io/netlogix/docker/frankenphp-cli:8.5 --build-arg PHP_VERSION=8.5 -f php/frankenphp.Dockerfile --target=frankenphp-cli php
+docker buildx build -t ghcr.io/netlogix/docker/frankenphp-cli-dev:8.5 --build-arg PHP_VERSION=8.5 -f php/frankenphp.Dockerfile --target=frankenphp-cli-dev php
+docker buildx build -t ghcr.io/netlogix/docker/frankenphp-cron:8.5 --build-arg PHP_VERSION=8.5 -f php/frankenphp.Dockerfile --target=frankenphp-cron php
+docker buildx build -t ghcr.io/netlogix/docker/frankenphp-cron-dev:8.5 --build-arg PHP_VERSION=8.5 -f php/frankenphp.Dockerfile --target=frankenphp-cron-dev php
 
 docker buildx build -t ghcr.io/netlogix/docker/node:18 --build-arg NODE_VERSION=18 -f node/Dockerfile node
 docker buildx build -t ghcr.io/netlogix/docker/node:20 --build-arg NODE_VERSION=20 -f node/Dockerfile node
 docker buildx build -t ghcr.io/netlogix/docker/node:22 --build-arg NODE_VERSION=22 -f node/Dockerfile node
+docker buildx build -t ghcr.io/netlogix/docker/node:24 --build-arg NODE_VERSION=24 -f node/Dockerfile node

--- a/php/frankenphp.Dockerfile
+++ b/php/frankenphp.Dockerfile
@@ -133,6 +133,18 @@ FROM frankenphp-base AS frankenphp-cli
 ENTRYPOINT [ "frankenphp", "php-cli" ]
 CMD []
 
+FROM frankenphp-base AS frankenphp-cron
+
+USER root
+
+ENV CRONTAB_PATH=/var/www/config/crontab
+# cron runs jobs with a minimal PATH (/usr/bin:/bin) that excludes /usr/local/bin, so
+# crontab entries calling plain `php` would fail without this symlink
+RUN ln -s /usr/local/bin/php /usr/bin/php
+
+ENTRYPOINT ["/bin/sh", "-c", "env > /etc/environment && crontab -u www-data - < \"$CRONTAB_PATH\" && exec cron -f"]
+CMD []
+
 FROM frankenphp-base AS frankenphp-base-dev
 
 USER root
@@ -185,4 +197,16 @@ LABEL prometheus_port="2019"
 
 FROM frankenphp-base-dev AS frankenphp-cli-dev
 ENTRYPOINT [ "frankenphp", "php-cli" ]
+CMD []
+
+FROM frankenphp-base-dev AS frankenphp-cron-dev
+
+USER root
+
+ENV CRONTAB_PATH=/var/www/config/crontab
+# cron runs jobs with a minimal PATH (/usr/bin:/bin) that excludes /usr/local/bin, so
+# crontab entries calling plain `php` would fail without this symlink
+RUN ln -s /usr/local/bin/php /usr/bin/php
+
+ENTRYPOINT ["/bin/sh", "-c", "env > /etc/environment && crontab -u www-data - < \"$CRONTAB_PATH\" && exec cron -f"]
 CMD []

--- a/php/frankenphp.Dockerfile
+++ b/php/frankenphp.Dockerfile
@@ -119,6 +119,10 @@ USER www-data
 
 RUN frankenphp adapt --config /etc/frankenphp/Caddyfile --pretty --validate
 
+HEALTHCHECK NONE
+
+FROM frankenphp-base AS frankenphp
+
 HEALTHCHECK --interval=2s --timeout=2s --start-period=2s --retries=3 \
   CMD curl --fail --silent http://localhost:8080/health-check || exit 1
 
@@ -175,6 +179,9 @@ COPY dev/scripts /usr/local/bin/
 USER www-data
 
 FROM frankenphp-base-dev AS frankenphp-dev
+
+HEALTHCHECK --interval=2s --timeout=2s --start-period=2s --retries=3 \
+  CMD curl --fail --silent http://localhost:8080/health-check || exit 1
 
 FROM frankenphp-base-dev AS frankenphp-cli-dev
 ENTRYPOINT [ "frankenphp", "php-cli" ]

--- a/php/frankenphp.Dockerfile
+++ b/php/frankenphp.Dockerfile
@@ -129,9 +129,6 @@ HEALTHCHECK --interval=2s --timeout=2s --start-period=2s --retries=3 \
 LABEL prometheus_port="2019"
 
 FROM frankenphp-base AS frankenphp-cli
-COPY --chown=www-data:www-data . /var/www/
-
-FROM frankenphp AS frankenphp-cli
 ENTRYPOINT [ "frankenphp", "php-cli" ]
 CMD []
 

--- a/php/frankenphp.Dockerfile
+++ b/php/frankenphp.Dockerfile
@@ -126,7 +126,7 @@ FROM frankenphp-base AS frankenphp
 HEALTHCHECK --interval=2s --timeout=2s --start-period=2s --retries=3 \
   CMD curl --fail --silent http://localhost:8080/health-check || exit 1
 
-LABEL prometheus_port="2020"
+LABEL prometheus_port="2019"
 
 FROM frankenphp-base AS frankenphp-cli
 COPY --chown=www-data:www-data . /var/www/
@@ -182,6 +182,8 @@ FROM frankenphp-base-dev AS frankenphp-dev
 
 HEALTHCHECK --interval=2s --timeout=2s --start-period=2s --retries=3 \
   CMD curl --fail --silent http://localhost:8080/health-check || exit 1
+
+LABEL prometheus_port="2019"
 
 FROM frankenphp-base-dev AS frankenphp-cli-dev
 ENTRYPOINT [ "frankenphp", "php-cli" ]

--- a/php/frankenphp.Dockerfile
+++ b/php/frankenphp.Dockerfile
@@ -1,6 +1,6 @@
 ARG PHP_VERSION=8.4
 
-FROM dunglas/frankenphp:php${PHP_VERSION} AS app-frankenphp-base
+FROM dunglas/frankenphp:php${PHP_VERSION} AS frankenphp-base
 RUN <<EOF
     set -e
     apt-get update -y
@@ -124,15 +124,14 @@ HEALTHCHECK --interval=2s --timeout=2s --start-period=2s --retries=3 \
 
 LABEL prometheus_port="2020"
 
-FROM app-frankenphp-base AS frankenphp
+FROM frankenphp-base AS frankenphp-cli
 COPY --chown=www-data:www-data . /var/www/
 
 FROM frankenphp AS frankenphp-cli
 ENTRYPOINT [ "frankenphp", "php-cli" ]
 CMD []
 
-
-FROM app-frankenphp-base AS frankenphp-base-dev
+FROM frankenphp-base AS frankenphp-base-dev
 
 USER root
 

--- a/php/frankenphp.Dockerfile
+++ b/php/frankenphp.Dockerfile
@@ -39,6 +39,7 @@ RUN <<EOF
         opcache \
         pcntl \
         pdo_mysql \
+        pdo_pgsql \
         pgsql \
         raphf \
         readline \

--- a/php/frankenphp.Dockerfile
+++ b/php/frankenphp.Dockerfile
@@ -124,10 +124,12 @@ HEALTHCHECK NONE
 
 FROM frankenphp-base AS frankenphp
 
+LABEL prometheus_port="2020"
+
 HEALTHCHECK --interval=2s --timeout=2s --start-period=2s --retries=3 \
   CMD curl --fail --silent http://localhost:8080/health-check || exit 1
 
-LABEL prometheus_port="2019"
+EXPOSE 2020
 
 FROM frankenphp-base AS frankenphp-cli
 ENTRYPOINT [ "frankenphp", "php-cli" ]
@@ -190,10 +192,12 @@ USER www-data
 
 FROM frankenphp-base-dev AS frankenphp-dev
 
+LABEL prometheus_port="2020"
+
 HEALTHCHECK --interval=2s --timeout=2s --start-period=2s --retries=3 \
   CMD curl --fail --silent http://localhost:8080/health-check || exit 1
 
-LABEL prometheus_port="2019"
+EXPOSE 2020
 
 FROM frankenphp-base-dev AS frankenphp-cli-dev
 ENTRYPOINT [ "frankenphp", "php-cli" ]


### PR DESCRIPTION
 Adds cron support to the FrankenPHP images and cleans up prometheus/healthcheck config, plus keeps build-container.sh and the CI workflow in sync with the Dockerfile targets.                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                                                                                         
  - Add frankenphp-cron / frankenphp-cron-dev targets — new stages that install a crontab from $CRONTAB_PATH and run cron -f, mirroring the existing fpm/cli/dev split. Symlinks /usr/local/bin/php to /usr/bin/php since cron's minimal PATH doesn't include /usr/local/bin.                                                                                                                            
  - Fix healthcheck scoping — HEALTHCHECK NONE on the shared frankenphp-base stage, with the real healthcheck only applied to the frankenphp/frankenphp-dev leaf targets (previously cli/cron images could inherit an inapplicable healthcheck).                                                                                                                                                         
  - Fix prometheus metrics port — corrected port/label mismatch and added EXPOSE 2020 on the runtime targets.                                                                                                                                                                                                                                                                                            
  - Fix build context leak — frankenphp no longer COPYs the Docker build context into /var/www/; app code is mounted/copied separately.                                                                                                                                                                                                                                                                  
  - Rename app-frankenphp-base → frankenphp-base for consistency with the other target names.                                                                                                                                                                                                                                                                                                            
  - Add pdo_pgsql PHP extension.                                                                                                                                                                                                                                                                                                                                                                         
  - CI/build script: added GitHub Actions build-and-push steps for frankenphp-cron/frankenphp-cron-dev, and updated build-container.sh to match (same build args/flags as the workflow, added missing 8.0 fpm-dev/cli-dev lines, added 8.5 and node:24 targets). 